### PR TITLE
fix: Use quantiles for color ranges

### DIFF
--- a/heatmap.js
+++ b/heatmap.js
@@ -522,9 +522,11 @@ export default function(config, helper) {
     vm._scales.color = d3
       .scaleQuantile()
       .domain(
-        d3.extent(vm._data, d => {
-          return d.value;
-        })
+        vm._data
+          .map(d => {
+            return d.value;
+          })
+          .sort()
       )
       .range(vm._config.colors);
 


### PR DESCRIPTION
Use quantiles (same length groups) for color ranges (by default 5 colors)

![image](https://user-images.githubusercontent.com/6007352/74867440-49c31c00-531a-11ea-9669-21226e8db566.png)
